### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,6 +2,7 @@ class ProductsController < ApplicationController
   before_action :move_to_index, except: [:index]
 
   def index
+    @products = Product.all
   end
 
   def new

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,26 +1,26 @@
 <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag product.image, class: "item-img" %>
-  
-          <%# 商品が売れていればsold outの表示
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          　//商品が売れていればsold outの表示 %>
+  <%= link_to "#" do %>
+    <div class='item-img-content'>
+      <%= image_tag product.image, class: "item-img" %>
 
+      <%# 商品が売れていればsold outの表示
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      　//商品が売れていればsold outの表示 %>
+
+    </div>
+    <div class='item-info'>
+      <h3 class='item-name'>
+        <%= product.name %>
+      </h3>
+      <div class='item-price'>
+        <span><%= product.selling_price %>円<br>(税込み)</span>
+        <div class='star-btn'>
+          <%= image_tag "star.png", class:"star-icon" %>
+          <span class='star-count'>0</span>
         </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= product.name %>
-          </h3>
-          <div class='item-price'>
-            <span><%= product.selling_price %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+      </div>
+    </div>
+  <% end %>
+</li>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,0 +1,26 @@
+<li class='list'>
+        <%= link_to "#" do %>
+        <div class='item-img-content'>
+          <%= image_tag product.image, class: "item-img" %>
+  
+          <%# 商品が売れていればsold outの表示
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+          　//商品が売れていればsold outの表示 %>
+
+        </div>
+        <div class='item-info'>
+          <h3 class='item-name'>
+            <%= product.name %>
+          </h3>
+          <div class='item-price'>
+            <span><%= product.selling_price %>円<br>(税込み)</span>
+            <div class='star-btn'>
+              <%= image_tag "star.png", class:"star-icon" %>
+              <span class='star-count'>0</span>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </li>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -126,56 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @products.each do |product| %>
+        <%= render partial: "product", locals: { product: product} %>
+      <% end %>
 
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outの表示 %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合のダミー %>
     </ul>
   </div>
   <%# //商品一覧 %>

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Product, type: :model do
       end
 
       it '価格の範囲が、¥9,999,999以上だと出品できない' do
-        @product.selling_price = 10000000
+        @product.selling_price = 10_000_000
         @product.valid?
         expect(@product.errors.full_messages).to include('Selling price must be less than or equal to 9999999')
       end


### PR DESCRIPTION
#what
商品一覧表示機能の作成

#why
商品一覧表示機能を実装する為

[gyazo url 実装機能の様子 ]
(https://gyazo.com/68ae5fe85d13adc623f1e8f7bc1b523f)

商品購入機能が未実装の為、購入されていた場合のsoldout表示は未実装です。